### PR TITLE
Now restart everytime insteaof of reloading Consul's configuration.

### DIFF
--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -45,13 +45,7 @@ module ConsulCookbook
       end
 
       def action_reload
-        notifying_block do
-          execute 'Reload consul' do
-            command 'consul.exe reload' + (new_resource.acl_token ? " -token=#{new_resource.acl_token}" : '')
-            cwd ::File.dirname(new_resource.program)
-            action :run
-          end
-        end
+        action_restart
       end
 
       def action_restart


### PR DESCRIPTION
It will avoid timeing issues in test (Consul on Windows take time to load)
It will avoid issues with options not being valid when upgrading Consul's version