### PR TITLE
Change mode of consul definition resource to 0640 to avoid ACL token leak.

### DIFF
--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -27,6 +27,10 @@ module ConsulCookbook
       # @return [String]
       attribute(:group, kind_of: String, default: lazy { node['consul']['service_group'] })
 
+      # @!attribute mode
+      # @return [String]
+      attribute(:mode, kind_of: String, default: '0640')
+
       # @!attribute type
       # @return [String]
       attribute(:type, equal_to: %w(check service checks services))
@@ -60,7 +64,7 @@ module ConsulCookbook
             unless platform?('windows')
               owner new_resource.user
               group new_resource.group
-              mode '0644'
+              mode new_resource.mode
             end
           end
         end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -73,7 +73,7 @@ describe file("#{confd_dir}/consul_definition_check.json") do
   it { should be_file }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'consul' }
-  its('mode') { should cmp '0644' }
+  its('mode') { should cmp '0640' }
 end
 
 describe file("#{confd_dir}/consul_watch_check.json") do

--- a/test/spec/libraries/consul_definition_spec.rb
+++ b/test/spec/libraries/consul_definition_spec.rb
@@ -26,7 +26,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     it { is_expected.to create_directory('/etc/consul/conf.d') }
     it do
       is_expected.to create_file('/etc/consul/conf.d/redis.json')
-        .with(user: 'root', group: 'consul', mode: '0644')
+        .with(user: 'root', group: 'consul', mode: '0640')
         .with(content: JSON.pretty_generate(
           service: {
             tags: ['master'],
@@ -51,7 +51,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     it { is_expected.to create_directory('/etc/consul/conf.d') }
     it do
       is_expected.to create_file('/etc/consul/conf.d/redis.json')
-        .with(user: 'root', group: 'consul', mode: '0644')
+        .with(user: 'root', group: 'consul', mode: '0640')
         .with(content: JSON.pretty_generate(
           service: {
             name: 'myredis',
@@ -85,7 +85,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     it { is_expected.to create_directory('/etc/consul/conf.d') }
     it do
       is_expected.to create_file('/etc/consul/conf.d/redis.json')
-        .with(user: 'root', group: 'root', mode: '0644')
+        .with(user: 'root', group: 'root', mode: '0640')
         .with(content: JSON.pretty_generate(
           service: {
             name: 'myredis',
@@ -110,7 +110,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     it { is_expected.to create_directory('/etc/consul/conf.d') }
     it do
       is_expected.to create_file('/etc/consul/conf.d/web-api.json')
-        .with(user: 'root', group: 'consul', mode: '0644')
+        .with(user: 'root', group: 'consul', mode: '0640')
         .with(content: JSON.pretty_generate(
           check: {
             http: 'http://localhost:5000/health',


### PR DESCRIPTION
With the current default mode for the definitions, any user on the machine running
the consul client can read the service definition holding the ACL token.
If an attacker get into the server as a non consul user, he could easily steal
tokens of all registered services.