### PR TITLE
Backport change to work with Chef 17

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '4.0.0'
+version '4.1.0'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,18 +22,18 @@ user node['consul']['service_user'] do
 end
 
 service_name = node['consul']['service_name']
-config = consul_config service_name do |r|
-  node['consul']['config'].each_pair { |k, v| r.send(k, v) }
+config = consul_config service_name do
+  node['consul']['config'].each_pair { |k, v| send(k.to_sym, v) }
   notifies :reload, "consul_service[#{service_name}]", :delayed
 end
 
-install = consul_installation node['consul']['version'] do |r|
+install = consul_installation node['consul']['version'] do
   if node['consul']['installation']
-    node['consul']['installation'].each_pair { |k, v| r.send(k, v) }
+    node['consul']['installation'].each_pair { |k, v| send(k.to_sym, v) }
   end
 end
 
-consul_service service_name do |r|
+consul_service service_name do
   config_file config.path
   program install.consul_program
 
@@ -44,6 +44,6 @@ consul_service service_name do |r|
     group node['consul']['service_group']
   end
   if node['consul']['service']
-    node['consul']['service'].each_pair { |k, v| r.send(k, v) }
+    node['consul']['service'].each_pair { |k, v| send(k.to_sym, v) }
   end
 end


### PR DESCRIPTION
For some reason, from chef >= 17.1 (not 17.0), resources do not yield object anymore (`r` is `nil`).
Rework the block to overcome the issue (change already in upstream).