### PR TITLE
Parametrize service action in case of content update

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ default['consul']['service_user'] = 'consul'
 default['consul']['service_group'] = 'consul'
 default['consul']['service_shell'] = '/bin/false'
 default['consul']['create_service_user'] = true
+default['consul']['service']['action_on_update'] = :reload
 
 default['consul']['config']['path'] = join_path config_prefix_path, 'consul.json'
 default['consul']['config']['data_dir'] = data_path

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ end
 service_name = node['consul']['service_name']
 config = consul_config service_name do
   node['consul']['config'].each_pair { |k, v| send(k.to_sym, v) }
-  notifies :reload, "consul_service[#{service_name}]", :delayed
+  notifies node['consul']['service']['action_on_update'], "consul_service[#{service_name}]", :delayed
 end
 
 install = consul_installation node['consul']['version'] do


### PR DESCRIPTION
Add a parameter to define the action to apply on service if content is updated.
Default value remains reload.