### PR TITLE
Fix parametrize service action in case of content update

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,7 +10,7 @@ default['consul']['service_user'] = 'consul'
 default['consul']['service_group'] = 'consul'
 default['consul']['service_shell'] = '/bin/false'
 default['consul']['create_service_user'] = true
-default['consul']['service']['action_on_update'] = :reload
+default['consul']['action_on_update'] = :reload
 
 default['consul']['config']['path'] = join_path config_prefix_path, 'consul.json'
 default['consul']['config']['data_dir'] = data_path

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ end
 service_name = node['consul']['service_name']
 config = consul_config service_name do
   node['consul']['config'].each_pair { |k, v| send(k.to_sym, v) }
-  notifies node['consul']['service']['action_on_update'], "consul_service[#{service_name}]", :delayed
+  notifies node['consul']['action_on_update'], "consul_service[#{service_name}]", :delayed
 end
 
 install = consul_installation node['consul']['version'] do


### PR DESCRIPTION
The previously used namespace caused issue while generating consul_service resource

` FATAL: NoMethodError: undefined method `action_on_update' for Custom resource consul_service from cookbook consul`

See http://tfitch.com/chef/2014/09/01/sending-name-value-pairs-from-chef-cookbook.html for detail about how to generate dynamic attributes, which is used here.

Moving to the _consul_ namespace to avoid this error.