### PR TITLE
add ui_config config field

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '4.2.1'
+version '4.2.2'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'

--- a/resources/config_v1.rb
+++ b/resources/config_v1.rb
@@ -140,6 +140,7 @@ property :tls_prefer_server_cipher_suites, equal_to: [true, false]
 property :translate_wan_addrs, equal_to: [true, false]
 property :ui, equal_to: [true, false]
 property :ui_dir, kind_of: String
+property :ui_config, [Hash, Mash]
 property :unix_sockets, kind_of: [Hash, Mash]
 property :verify_incoming, equal_to: [true, false]
 property :verify_incoming_https, equal_to: [true, false]
@@ -247,6 +248,7 @@ def params_to_json
   translate_wan_addrs
   ui
   ui_dir
+  ui_config
   unix_sockets
   verify_incoming
   verify_incoming_https


### PR DESCRIPTION
Update config_v1 to match the upstream repository.

Consul configuration evolved since 1.9 and some fields are deprecated (see [this](https://developer.hashicorp.com/consul/docs/agent/config/config-files#ui-parameters))

This PR aims to match the current state of the UI parameters.