### PR TITLE
add tls config field

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '4.2.2'
+version '4.2.3'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'

--- a/resources/config_v1.rb
+++ b/resources/config_v1.rb
@@ -134,6 +134,7 @@ property :statsite_address, kind_of: String
 property :statsite_prefix, kind_of: String
 property :telemetry, kind_of: [Hash, Mash]
 property :syslog_facility, kind_of: String
+property :tls, kind_of: [Hash, Mash]
 property :tls_cipher_suites, kind_of: String
 property :tls_min_version, equal_to: %w(tls10 tls11 tls12)
 property :tls_prefer_server_cipher_suites, equal_to: [true, false]
@@ -242,6 +243,7 @@ def params_to_json
   start_join_wan
   syslog_facility
   telemetry
+  tls
   tls_cipher_suites
   tls_min_version
   tls_prefer_server_cipher_suites


### PR DESCRIPTION
Update config_v1 to handle tls stanza in the config file.

Consul configuration evolved since 1.9 and some fields are deprecated (see [this](https://developer.hashicorp.com/consul/docs/agent/config/config-files#tls-1))

This PR aims to match the current state of the TLS parameters.