### PR TITLE
Mark consul definitions as sensitive assets

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '4.2.3'
+version '4.2.4'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'

--- a/resources/definition.rb
+++ b/resources/definition.rb
@@ -40,6 +40,7 @@ action :create do
 
   file new_resource.path do
     content new_resource.params_to_json
+    sensitive true
     unless platform?('windows')
       owner new_resource.user
       group new_resource.group


### PR DESCRIPTION
As definitions may contains tokens, we should avoid their leak into any logged output.