### PR TITLE
Protect consul service by choregraphie

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -83,6 +83,7 @@ action :enable do
     )
     notifies :restart, 'service[consul]' if new_resource.restart_on_update
     action %i(create enable)
+    weight 1
   end
 
   service 'consul' do


### PR DESCRIPTION
By adding a weight in the consul systemd service, it is guaranteed to be protected by the choregraphie on resource :weighted_resources.