### PR TITLE
Revert protect consul service by choregraphie

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '4.2.6'
+version '4.2.7'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -83,7 +83,6 @@ action :enable do
     )
     notifies :restart, 'service[consul]' if new_resource.restart_on_update
     action %i(create enable)
-    weight 1
   end
 
   service 'consul' do


### PR DESCRIPTION
The weight attribute does not exist in systemd_unit resource causing error
`    NoMethodError: undefined method 'weight'`

It seems to exist in resource systemd_service_drop_in - to be pushed in another patch. In the meantime, reverting to avoid breakage.