### PR TITLE
Protect consul service by choregraphie (2)

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '4.2.7'
+version '4.2.8'
 
 recipe 'consul::default', 'Installs and configures the Consul service.'
 recipe 'consul::client_gem', 'Installs the Consul Ruby client as a gem.'
@@ -17,6 +17,7 @@ supports 'arch'
 supports 'windows'
 
 depends 'nssm', '>= 3.42.0'
+depends 'resource-weight'
 
 source_url 'https://github.com/johnbellone/consul-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/johnbellone/consul-cookbook/issues' if respond_to?(:issues_url)

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -83,6 +83,7 @@ action :enable do
     )
     notifies :restart, 'service[consul]' if new_resource.restart_on_update
     action %i(create enable)
+    weight 1
   end
 
   service 'consul' do


### PR DESCRIPTION
By adding a weight in the consul systemd service, it is guaranteed to be protected by the choregraphie on resource :weighted_resources.
This is the second attempt with this time the addition of the right dependency.